### PR TITLE
[Ownit 4] Página de Listagem dos Planos (depends on: Ownit 27)

### DIFF
--- a/ui/src/features/goals/components/goal-detail.tsx
+++ b/ui/src/features/goals/components/goal-detail.tsx
@@ -1,3 +1,25 @@
+import Header from '@/features/appshell/header';
+import { Center, Container, Group, Text } from '@mantine/core';
+import { BookOpenIcon } from '@phosphor-icons/react';
+
 export default function GoalDetails() {
-  return <div>aham</div>;
+  return (
+    <>
+      <Header
+        title="{goal.title}"
+        description="{goal.description}"
+        icon={<BookOpenIcon weight="bold" color="white" size={32} />}
+      >
+        <Group gap="sm">
+          <>{'{métricas}'}</>
+        </Group>
+      </Header>
+
+      <Container py="xl" w="100%" fluid>
+        <Center py="lg">
+          <Text c="dimmed">Imagine a página do plano aqui.</Text>
+        </Center>
+      </Container>
+    </>
+  );
 }

--- a/ui/src/features/goals/components/goal-detail.tsx
+++ b/ui/src/features/goals/components/goal-detail.tsx
@@ -1,0 +1,3 @@
+export default function GoalDetails() {
+  return <div>aham</div>;
+}

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -79,6 +79,7 @@ interface GoalListProps {
 
 function GoalsList({ goals, isLoading, error }: GoalListProps) {
   const navigate = useNavigate();
+  const [hoveredGoalId, setHoveredGoalId] = useState<string | null>(null);
 
   function handleClick(id: string) {
     void navigate({ to: '/goals/$goal_id', params: { goal_id: id } });
@@ -101,7 +102,7 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
   }
 
   return (
-    <Grid gap="md">
+    <Grid gap="md" align="stretch">
       {goals && goals.length > 0 ? (
         goals.map((goal) => {
           // TODO: Calcular o progresso quando tivermos as sessões
@@ -127,14 +128,29 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
             <Grid.Col span={{ base: 12, md: 4 }} key={goal.id}>
               <Card
                 key={goal.id}
+                withBorder
                 padding="lg"
                 radius="md"
-                shadow="md"
+                h="100%"
+                w="100%"
+                shadow={hoveredGoalId === goal.id ? 'lg' : 'md'}
                 onClick={() => handleClick(goal.id)}
-                style={{ cursor: 'pointer' }}
+                onMouseEnter={() => setHoveredGoalId(goal.id)}
+                onMouseLeave={() => setHoveredGoalId(null)}
+                style={{
+                  cursor: 'pointer',
+                  transition:
+                    'transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease',
+                  transform:
+                    hoveredGoalId === goal.id ? 'translateY(-4px)' : 'none',
+                  borderColor:
+                    hoveredGoalId === goal.id
+                      ? 'var(--mantine-color-orange-4)'
+                      : undefined,
+                }}
               >
-                <Card.Section inheritPadding py="md">
-                  <Stack gap="md">
+                <Card.Section inheritPadding py="md" flex={1} h="100%">
+                  <Stack gap="md" justify="space-between" h="100%">
                     <Stack gap="sm">
                       <Group justify="space-between">
                         <BookOpenIcon size={32} color="orange" weight="bold" />

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -129,6 +129,7 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
                 key={goal.id}
                 padding="lg"
                 radius="md"
+                shadow="md"
                 onClick={() => handleClick(goal.id)}
                 style={{ cursor: 'pointer' }}
               >

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -27,6 +27,7 @@ import { getStudentGoalsOptions } from '../api';
 import type { Goal } from '../models';
 import CreateGoalModal from './create-goal-modal';
 import FilterGoalsModal, { type FilterGoalsValues } from './filter-goals-modal';
+import { statusMapper } from '../mappers';
 
 export default function Goals() {
   const { student } = useRouteContext({ from: '/goals/' });
@@ -154,7 +155,7 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
                     <Stack gap="sm">
                       <Group justify="space-between">
                         <BookOpenIcon size={32} color="orange" weight="bold" />
-                        <Badge variant="light">{goal.status}</Badge>
+                        <Badge variant="light">{statusMapper(goal.status)}</Badge>
                       </Group>
                       <Stack gap={0}>
                         <Title order={4} size="lg">

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -64,7 +64,7 @@ export default function Goals() {
         </Group>
       </Header>
 
-      <Container py="xl" w="100%" fluid>
+      <Container py="xl" mx="xl" fluid>
         <GoalsList goals={goals} isLoading={isLoading} error={error} />
       </Container>
     </>
@@ -125,7 +125,7 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
           }
 
           return (
-            <Grid.Col span={{ base: 12, md: 4 }} key={goal.id}>
+            <Grid.Col span={{ base: 12, md: 3 }} key={goal.id}>
               <Card
                 key={goal.id}
                 withBorder

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -5,14 +5,22 @@ import {
   Card,
   Center,
   Container,
+  Divider,
+  Grid,
   Group,
   Loader,
+  Progress,
   Stack,
   Text,
+  Title,
 } from '@mantine/core';
-import { TargetIcon } from '@phosphor-icons/react';
+import {
+  BookOpenIcon,
+  CaretRightIcon,
+  TargetIcon,
+} from '@phosphor-icons/react';
 import { useQuery } from '@tanstack/react-query';
-import { useRouteContext } from '@tanstack/react-router';
+import { useNavigate, useRouteContext } from '@tanstack/react-router';
 import { useState } from 'react';
 
 import { getStudentGoalsOptions } from '../api';
@@ -56,7 +64,7 @@ export default function Goals() {
         </Group>
       </Header>
 
-      <Container py="xl">
+      <Container py="xl" w="100%" fluid>
         <GoalsList goals={goals} isLoading={isLoading} error={error} />
       </Container>
     </>
@@ -70,6 +78,12 @@ interface GoalListProps {
 }
 
 function GoalsList({ goals, isLoading, error }: GoalListProps) {
+  const navigate = useNavigate();
+
+  function handleClick(id: string) {
+    void navigate({ to: '/goals/$goal_id', params: { goal_id: id } });
+  }
+
   if (goals === undefined && isLoading) {
     return (
       <Center>
@@ -87,43 +101,88 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
   }
 
   return (
-    <Stack gap="md">
+    <Grid gap="md">
       {goals && goals.length > 0 ? (
-        goals.map((goal) => (
-          <Card key={goal.id} padding="lg" radius="md" withBorder>
-            <Card.Section withBorder inheritPadding py="md">
-              <Group justify="space-between">
-                <Text fw={600} size="lg">
-                  {goal.title}
-                </Text>
-                <Badge color="blue" variant="light">
-                  {goal.status}
-                </Badge>
-              </Group>
-            </Card.Section>
+        goals.map((goal) => {
+          // TODO: Calcular o progresso quando tivermos as sessões
+          const mockProgressValue = 0;
 
-            <Card.Section inheritPadding py="md">
-              {goal.description && (
-                <Text size="sm" c="dimmed" mb="md">
-                  {goal.description}
-                </Text>
-              )}
-              <Group justify="space-between">
-                <Text size="sm">
-                  <strong>Tags:</strong> {goal.goal_tags.join(', ')}
-                </Text>
-                <Text size="xs" c="dimmed">
-                  Atualizado: {goal.updated_at.toLocaleDateString('pt-BR')}
-                </Text>
-              </Group>
-            </Card.Section>
-          </Card>
-        ))
+          let leftDays = 0;
+          if (goal.start_date && goal.end_date) {
+            const utcA = Date.UTC(
+              goal.start_date.getFullYear(),
+              goal.start_date.getMonth(),
+              goal.start_date.getDate(),
+            );
+            const utcB = Date.UTC(
+              goal.end_date.getFullYear(),
+              goal.end_date.getMonth(),
+              goal.end_date.getDate(),
+            );
+            const msPerDay = 24 * 60 * 60 * 1000;
+            leftDays = Math.abs(Math.floor((utcA - utcB) / msPerDay));
+          }
+
+          return (
+            <Grid.Col span={{ base: 12, md: 4 }} key={goal.id}>
+              <Card
+                key={goal.id}
+                padding="lg"
+                radius="md"
+                onClick={() => handleClick(goal.id)}
+                style={{ cursor: 'pointer' }}
+              >
+                <Card.Section inheritPadding py="md">
+                  <Stack gap="md">
+                    <Stack gap="sm">
+                      <Group justify="space-between">
+                        <BookOpenIcon size={32} color="orange" weight="bold" />
+                        <Badge variant="light">{goal.status}</Badge>
+                      </Group>
+                      <Stack gap={0}>
+                        <Title order={4} size="lg">
+                          {goal.title}
+                        </Title>
+                        {goal.description && (
+                          <Text size="sm" c="dimmed">
+                            {goal.description}
+                          </Text>
+                        )}
+                      </Stack>
+                    </Stack>
+
+                    <Stack gap="xs">
+                      <Stack gap={0}>
+                        <Group justify="space-between">
+                          <Text c="dimmed" size="sm" fw={600}>
+                            Progresso
+                          </Text>
+                          <Text c="orange" size="lg" fw={600}>
+                            {mockProgressValue}%
+                          </Text>
+                        </Group>
+                        <Progress value={mockProgressValue} />
+                      </Stack>
+
+                      <Divider />
+                      <Group justify="space-between">
+                        <Text c="dimmed" size="sm" fw={600}>
+                          {leftDays} dias
+                        </Text>
+                        <CaretRightIcon />
+                      </Group>
+                    </Stack>
+                  </Stack>
+                </Card.Section>
+              </Card>
+            </Grid.Col>
+          );
+        })
       ) : (
         <Center py="lg">
           <Text c="dimmed">Nenhum plano criado ainda</Text>
         </Center>
       )}
-    </Stack>
+    </Grid>
   );
 }

--- a/ui/src/features/goals/components/goals.tsx
+++ b/ui/src/features/goals/components/goals.tsx
@@ -155,7 +155,9 @@ function GoalsList({ goals, isLoading, error }: GoalListProps) {
                     <Stack gap="sm">
                       <Group justify="space-between">
                         <BookOpenIcon size={32} color="orange" weight="bold" />
-                        <Badge variant="light">{statusMapper(goal.status)}</Badge>
+                        <Badge variant="light">
+                          {statusMapper(goal.status)}
+                        </Badge>
                       </Group>
                       <Stack gap={0}>
                         <Title order={4} size="lg">

--- a/ui/src/routeTree.gen.ts
+++ b/ui/src/routeTree.gen.ts
@@ -13,6 +13,7 @@ import { Route as LoginRouteImport } from './routes/login'
 import { Route as IndexRouteImport } from './routes/index'
 import { Route as StatisticsIndexRouteImport } from './routes/statistics/index'
 import { Route as GoalsIndexRouteImport } from './routes/goals/index'
+import { Route as GoalsGoal_idRouteImport } from './routes/goals/$goal_id'
 
 const LoginRoute = LoginRouteImport.update({
   id: '/login',
@@ -34,16 +35,23 @@ const GoalsIndexRoute = GoalsIndexRouteImport.update({
   path: '/goals/',
   getParentRoute: () => rootRouteImport,
 } as any)
+const GoalsGoal_idRoute = GoalsGoal_idRouteImport.update({
+  id: '/goals/$goal_id',
+  path: '/goals/$goal_id',
+  getParentRoute: () => rootRouteImport,
+} as any)
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/goals/$goal_id': typeof GoalsGoal_idRoute
   '/goals/': typeof GoalsIndexRoute
   '/statistics/': typeof StatisticsIndexRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/goals/$goal_id': typeof GoalsGoal_idRoute
   '/goals': typeof GoalsIndexRoute
   '/statistics': typeof StatisticsIndexRoute
 }
@@ -51,20 +59,28 @@ export interface FileRoutesById {
   __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/login': typeof LoginRoute
+  '/goals/$goal_id': typeof GoalsGoal_idRoute
   '/goals/': typeof GoalsIndexRoute
   '/statistics/': typeof StatisticsIndexRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
-  fullPaths: '/' | '/login' | '/goals/' | '/statistics/'
+  fullPaths: '/' | '/login' | '/goals/$goal_id' | '/goals/' | '/statistics/'
   fileRoutesByTo: FileRoutesByTo
-  to: '/' | '/login' | '/goals' | '/statistics'
-  id: '__root__' | '/' | '/login' | '/goals/' | '/statistics/'
+  to: '/' | '/login' | '/goals/$goal_id' | '/goals' | '/statistics'
+  id:
+    | '__root__'
+    | '/'
+    | '/login'
+    | '/goals/$goal_id'
+    | '/goals/'
+    | '/statistics/'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   LoginRoute: typeof LoginRoute
+  GoalsGoal_idRoute: typeof GoalsGoal_idRoute
   GoalsIndexRoute: typeof GoalsIndexRoute
   StatisticsIndexRoute: typeof StatisticsIndexRoute
 }
@@ -99,12 +115,20 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof GoalsIndexRouteImport
       parentRoute: typeof rootRouteImport
     }
+    '/goals/$goal_id': {
+      id: '/goals/$goal_id'
+      path: '/goals/$goal_id'
+      fullPath: '/goals/$goal_id'
+      preLoaderRoute: typeof GoalsGoal_idRouteImport
+      parentRoute: typeof rootRouteImport
+    }
   }
 }
 
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   LoginRoute: LoginRoute,
+  GoalsGoal_idRoute: GoalsGoal_idRoute,
   GoalsIndexRoute: GoalsIndexRoute,
   StatisticsIndexRoute: StatisticsIndexRoute,
 }

--- a/ui/src/routes/goals/$goal_id.tsx
+++ b/ui/src/routes/goals/$goal_id.tsx
@@ -1,6 +1,6 @@
 import { createFileRoute, redirect } from '@tanstack/react-router';
 
-import { fetchMe } from '@/features/auth/api'; 
+import { fetchMe } from '@/features/auth/api';
 import GoalDetails from '@/features/goals/components/goal-detail';
 
 export const Route = createFileRoute('/goals/$goal_id')({

--- a/ui/src/routes/goals/$goal_id.tsx
+++ b/ui/src/routes/goals/$goal_id.tsx
@@ -1,0 +1,16 @@
+import { createFileRoute, redirect } from '@tanstack/react-router';
+
+import { fetchMe } from '@/features/auth/api'; 
+import GoalDetails from '@/features/goals/components/goal-detail';
+
+export const Route = createFileRoute('/goals/$goal_id')({
+  beforeLoad: async () => {
+    try {
+      const student = await fetchMe();
+      return { student };
+    } catch (error) {
+      throw redirect({ to: '/login' });
+    }
+  },
+  component: GoalDetails,
+});


### PR DESCRIPTION
## Tipo de mudança
- Feature

## Propósito da PR
Esta PR atualiza a página de Listagem dos Planos, com a criação do componente GoalCard. Também atualiza a configuração de rotas, adicionando uma rota dinâmica para a página de um Plano. 

## O que foi alterado
- Adicionado uma nova página `GoalDetails` (`goal-detail.tsx`), registrada na rota `/goals/$goal_id`, incluindo verificações de autenticação antes de carregar a página.
- Atualizada a lista de planos para exibi-las em uma grade responsiva. Os cards agora são clicáveis ​​e levam à nova página de detalhes do Plano.
- Aprimoramos os cards da lista de planos com novos ícones, barras de progresso,  dias restantes e UI de acordo com o design.
- Ajuste no padding e margin do container para melhor alinhamento.

## Task relacionada
closes #4 