### PR TITLE
[Ownit 62 clean] feat: edição de uma sessão 

### DIFF
--- a/ui/src/features/goal/api.ts
+++ b/ui/src/features/goal/api.ts
@@ -6,7 +6,9 @@ import type {
   StrategyMetricsData,
   StudySession,
   StudySessionWithHistory,
+  UpdateStudySessionData,
 } from './models';
+import { durationToIso } from '@/shared/utils';
 import type {
   GoalWithSessionsDTO,
   MetricsDTO,
@@ -102,6 +104,31 @@ export async function createStudySession(
     throw new Error(
       `Falha ao criar study session: ${response.status} ${response.statusText}`,
     );
+  }
+
+  const dto: StudySessionDTO = await response.json();
+  return studySessionMapper.fromDTO(dto);
+}
+
+export async function updateStudySession(
+  data: UpdateStudySessionData,
+): Promise<StudySession> {
+  const { sessionId, duration, ...rest } = data;
+  const url = `${import.meta.env.VITE_API_URL}/sessions/${sessionId}`;
+  const response = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({
+      ...rest,
+      ...(duration !== undefined && { duration: durationToIso(duration) }),
+    }),
+  });
+
+  if (!response.ok) {
+    const body = await response.json().catch(() => null);
+    const detail = body?.detail ?? `${response.status} ${response.statusText}`;
+    throw new Error(detail);
   }
 
   const dto: StudySessionDTO = await response.json();

--- a/ui/src/features/goal/components/create-session-modal.tsx
+++ b/ui/src/features/goal/components/create-session-modal.tsx
@@ -148,7 +148,7 @@ export default function CreateSessionModal({
                   leftSection={<IconCalendar size={18} />}
                   label="Data Planejada"
                   placeholder="Insira a data que planeja executar essa sessão"
-                  valueFormat="DD MMM YYYY hh:mm"
+                  valueFormat="DD MMM YYYY HH:mm"
                   minDate={new Date()}
                   required
                   {...form.getInputProps('planned_date')}

--- a/ui/src/features/goal/components/edit-session-modal.tsx
+++ b/ui/src/features/goal/components/edit-session-modal.tsx
@@ -114,7 +114,7 @@ export default function EditSessionModal({
                 leftSection={<IconCalendar size={18} />}
                 label="Data Planejada"
                 placeholder="Insira a data que planeja executar essa sessão"
-                valueFormat="DD MMM YYYY hh:mm"
+                valueFormat="DD MMM YYYY HH:mm"
                 required
                 {...form.getInputProps('planned_date')}
               />

--- a/ui/src/features/goal/components/edit-session-modal.tsx
+++ b/ui/src/features/goal/components/edit-session-modal.tsx
@@ -1,0 +1,148 @@
+import {
+  Button,
+  Group,
+  Modal,
+  Stack,
+  Text,
+  Textarea,
+  TextInput,
+} from '@mantine/core';
+import { DateTimePicker, TimePicker } from '@mantine/dates';
+import { useForm } from '@mantine/form';
+import { showNotification } from '@mantine/notifications';
+import { IconCalendar, IconClock } from '@tabler/icons-react';
+import { useUpdateStudySession } from '../hooks';
+import type { StudySessionShort } from '../models';
+
+interface EditSessionFormValues {
+  title: string;
+  description: string;
+  planned_date: Date | null;
+  session_duration: string;
+}
+
+interface EditSessionModalProps {
+  goalId: string;
+  session: StudySessionShort;
+  opened: boolean;
+  onClose: () => void;
+}
+
+export default function EditSessionModal({
+  goalId,
+  session,
+  opened,
+  onClose,
+}: EditSessionModalProps) {
+  const form = useForm<EditSessionFormValues>({
+    initialValues: {
+      title: session.title,
+      description: session.description,
+      planned_date: session.plannedToStartAt,
+      session_duration: session.duration,
+    },
+    validate: {
+      title: (value) =>
+        value.trim().length < 3
+          ? 'Título deve ter pelo menos 3 caracteres'
+          : null,
+      planned_date: (value) => (!value ? 'Selecione a data planejada' : null),
+      session_duration: (value) =>
+        !value ? 'Informe a duração da sessão' : null,
+    },
+  });
+
+  const updateMutation = useUpdateStudySession(goalId);
+
+  function handleSubmit(values: EditSessionFormValues) {
+    updateMutation.mutate(
+      {
+        sessionId: session.id,
+        title: values.title,
+        description: values.description,
+        planned_to_start_at: values.planned_date,
+        duration: values.session_duration,
+      },
+      {
+        onSuccess: () => {
+          showNotification({
+            title: 'Sessão atualizada',
+            message: 'As alterações foram salvas com sucesso.',
+            color: 'green',
+          });
+          onClose();
+        },
+      },
+    );
+  }
+
+  return (
+    <Modal.Root opened={opened} onClose={onClose} size="500px">
+      <Modal.Overlay />
+      <Modal.Content>
+        <Modal.Header>
+          <Stack gap={1} w="100%">
+            <Group justify="space-between">
+              <Modal.Title>Editar Sessão</Modal.Title>
+              <Modal.CloseButton />
+            </Group>
+            <Text c="dimmed" size="sm">
+              Altere os campos abaixo para editar a sessão de estudos.
+            </Text>
+          </Stack>
+        </Modal.Header>
+        <Modal.Body>
+          <form onSubmit={form.onSubmit(handleSubmit)}>
+            <Stack>
+              <TextInput
+                label="Título"
+                placeholder="Digite o título da sessão"
+                radius="sm"
+                required
+                {...form.getInputProps('title')}
+              />
+
+              <Textarea
+                label="Descrição"
+                placeholder="Descreva a sessão"
+                radius="sm"
+                minRows={3}
+                {...form.getInputProps('description')}
+              />
+
+              <DateTimePicker
+                leftSection={<IconCalendar size={18} />}
+                label="Data Planejada"
+                placeholder="Insira a data que planeja executar essa sessão"
+                valueFormat="DD MMM YYYY hh:mm"
+                required
+                {...form.getInputProps('planned_date')}
+              />
+
+              <TimePicker
+                leftSection={<IconClock size={16} />}
+                label="Duração da Sessão"
+                required
+                {...form.getInputProps('session_duration')}
+              />
+
+              <Group justify="flex-end" mt="md">
+                <Button variant="light" radius="sm" onClick={onClose}>
+                  Cancelar
+                </Button>
+                <Button
+                  type="submit"
+                  radius="sm"
+                  loading={updateMutation.isPending}
+                  disabled={!form.isValid()}
+                >
+                  Salvar
+                </Button>
+              </Group>
+            </Stack>
+          </form>
+        </Modal.Body>
+      </Modal.Content>
+    </Modal.Root>
+  );
+}

--- a/ui/src/features/goal/components/session-card.tsx
+++ b/ui/src/features/goal/components/session-card.tsx
@@ -1,8 +1,21 @@
 import type { StudySessionShort } from '@/features/goal/models';
 import { useDraggable } from '@dnd-kit/react';
-import { ActionIcon, Card, Group, Menu, Text, Title, Tooltip } from '@mantine/core';
+import {
+  ActionIcon,
+  Card,
+  Group,
+  Menu,
+  Text,
+  Title,
+  Tooltip,
+} from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
-import { IconCalendar, IconClock, IconDots, IconPencil } from '@tabler/icons-react';
+import {
+  IconCalendar,
+  IconClock,
+  IconDots,
+  IconPencil,
+} from '@tabler/icons-react';
 import { useNavigate } from '@tanstack/react-router';
 import EditSessionModal from './edit-session-modal';
 
@@ -13,7 +26,8 @@ interface SessionCardProps {
 
 export default function SessionCard({ session, goalId }: SessionCardProps) {
   const navigate = useNavigate();
-  const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false);
+  const [editOpened, { open: openEdit, close: closeEdit }] =
+    useDisclosure(false);
 
   const { ref, isDragging } = useDraggable({
     id: session.id,

--- a/ui/src/features/goal/components/session-card.tsx
+++ b/ui/src/features/goal/components/session-card.tsx
@@ -1,15 +1,19 @@
 import type { StudySessionShort } from '@/features/goal/models';
 import { useDraggable } from '@dnd-kit/react';
-import { Card, Group, Text, Title } from '@mantine/core';
-import { IconCalendar, IconClock } from '@tabler/icons-react';
+import { ActionIcon, Card, Group, Menu, Text, Title, Tooltip } from '@mantine/core';
+import { useDisclosure } from '@mantine/hooks';
+import { IconCalendar, IconClock, IconDots, IconPencil } from '@tabler/icons-react';
 import { useNavigate } from '@tanstack/react-router';
+import EditSessionModal from './edit-session-modal';
 
 interface SessionCardProps {
   session: StudySessionShort;
+  goalId: string;
 }
 
-export default function SessionCard({ session }: SessionCardProps) {
+export default function SessionCard({ session, goalId }: SessionCardProps) {
   const navigate = useNavigate();
+  const [editOpened, { open: openEdit, close: closeEdit }] = useDisclosure(false);
 
   const { ref, isDragging } = useDraggable({
     id: session.id,
@@ -31,37 +35,75 @@ export default function SessionCard({ session }: SessionCardProps) {
   };
 
   return (
-    <Card
-      ref={ref}
-      padding="md"
-      radius="lg"
-      withBorder
-      style={{
-        opacity: isDragging ? 0.4 : 1,
-        cursor: session.status === 'done' ? 'default' : 'grab',
-      }}
-      onClick={handleClick}
-    >
-      <Title order={5} mb={4}>
-        {session.title}
-      </Title>
-      <Text size="sm" c="dimmed" mb="sm">
-        {session.description}
-      </Text>
-      <Group gap="lg">
-        <Group gap={4}>
-          <IconCalendar size={16} color="#868E96" />
-          <Text size="xs" c="dimmed">
-            {formatDate(session.plannedToStartAt)}
-          </Text>
+    <>
+      <Card
+        ref={ref}
+        padding="md"
+        radius="lg"
+        withBorder
+        style={{
+          opacity: isDragging ? 0.4 : 1,
+          cursor: session.status === 'done' ? 'default' : 'grab',
+        }}
+        onClick={handleClick}
+      >
+        <Group justify="space-between" align="flex-start" mb={4}>
+          <Title order={5} style={{ flex: 1 }}>
+            {session.title}
+          </Title>
+          <Menu position="bottom-end" withinPortal>
+            <Menu.Target>
+              <ActionIcon
+                variant="subtle"
+                color="gray"
+                size="sm"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <IconDots size={16} />
+              </ActionIcon>
+            </Menu.Target>
+            <Menu.Dropdown onClick={(e) => e.stopPropagation()}>
+              <Tooltip
+                label="Não é possível editar uma sessão concluída"
+                disabled={session.status !== 'done'}
+                position="right"
+              >
+                <Menu.Item
+                  leftSection={<IconPencil size={14} />}
+                  disabled={session.status === 'done'}
+                  onClick={openEdit}
+                >
+                  Editar
+                </Menu.Item>
+              </Tooltip>
+            </Menu.Dropdown>
+          </Menu>
         </Group>
-        <Group gap={4}>
-          <IconClock size={16} color="#868E96" />
-          <Text size="xs" c="dimmed">
-            {session.duration}
-          </Text>
+        <Text size="sm" c="dimmed" mb="sm">
+          {session.description}
+        </Text>
+        <Group gap="lg">
+          <Group gap={4}>
+            <IconCalendar size={16} color="#868E96" />
+            <Text size="xs" c="dimmed">
+              {formatDate(session.plannedToStartAt)}
+            </Text>
+          </Group>
+          <Group gap={4}>
+            <IconClock size={16} color="#868E96" />
+            <Text size="xs" c="dimmed">
+              {session.duration}
+            </Text>
+          </Group>
         </Group>
-      </Group>
-    </Card>
+      </Card>
+
+      <EditSessionModal
+        goalId={goalId}
+        session={session}
+        opened={editOpened}
+        onClose={closeEdit}
+      />
+    </>
   );
 }

--- a/ui/src/features/goal/components/session-kanban.tsx
+++ b/ui/src/features/goal/components/session-kanban.tsx
@@ -195,7 +195,13 @@ interface SessionColumnProps {
   goalId: string;
 }
 
-function SessionColumn({ status, title, sessions, icon, goalId }: SessionColumnProps) {
+function SessionColumn({
+  status,
+  title,
+  sessions,
+  icon,
+  goalId,
+}: SessionColumnProps) {
   const { ref, isDropTarget } = useDroppable({
     id: `column-${status}`,
     data: { status },

--- a/ui/src/features/goal/components/session-kanban.tsx
+++ b/ui/src/features/goal/components/session-kanban.tsx
@@ -126,24 +126,28 @@ export default function SessionKanban({
               title="Ativa"
               sessions={activeSessions}
               icon={<IconPencil size={16} color="#000" />}
+              goalId={goalId}
             />
             <SessionColumn
               status="to_do"
               title="Pendentes"
               sessions={pendingSessions}
               icon={<IconHourglass size={16} color="#000" />}
+              goalId={goalId}
             />
             <SessionColumn
               status="done"
               title="Concluídas"
               sessions={completedSessions}
               icon={<IconCircleCheck size={16} color="#000" />}
+              goalId={goalId}
             />
             <SessionColumn
               status="canceled"
               title="Canceladas"
               sessions={canceledSessions}
               icon={<IconCircleX size={16} color="#000" />}
+              goalId={goalId}
             />
           </Stack>
         </Stack>
@@ -188,9 +192,10 @@ interface SessionColumnProps {
   title: string;
   sessions: StudySessionShort[];
   icon: React.ReactNode;
+  goalId: string;
 }
 
-function SessionColumn({ status, title, sessions, icon }: SessionColumnProps) {
+function SessionColumn({ status, title, sessions, icon, goalId }: SessionColumnProps) {
   const { ref, isDropTarget } = useDroppable({
     id: `column-${status}`,
     data: { status },
@@ -221,7 +226,7 @@ function SessionColumn({ status, title, sessions, icon }: SessionColumnProps) {
         {sessions.length > 0 ? (
           <Stack gap="xs">
             {sessions.map((session) => (
-              <SessionCard key={session.id} session={session} />
+              <SessionCard key={session.id} session={session} goalId={goalId} />
             ))}
           </Stack>
         ) : (

--- a/ui/src/features/goal/hooks.ts
+++ b/ui/src/features/goal/hooks.ts
@@ -9,6 +9,7 @@ import {
   evaluateStudySession,
   getGoalOptions,
   getMetricsOptions,
+  updateStudySession,
   updateStudySessionStatus,
 } from './api';
 import type { Status } from '@/shared/models';
@@ -98,6 +99,29 @@ export function useEvaluateStudySession(goalId: string) {
       showNotification({
         title: 'Erro ao finalizar sessão.',
         message: 'Não foi possível finalizar a sessão.',
+        color: 'red',
+      });
+    },
+  });
+}
+
+export function useUpdateStudySession(goalId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: updateStudySession,
+    onSuccess: () => {
+      queryClient.invalidateQueries({
+        queryKey: getGoalOptions(goalId).queryKey,
+      });
+      queryClient.invalidateQueries({
+        queryKey: getMetricsOptions(goalId).queryKey,
+      });
+    },
+    onError: () => {
+      showNotification({
+        title: 'Erro ao editar sessão',
+        message: 'Não foi possível salvar as alterações.',
         color: 'red',
       });
     },

--- a/ui/src/features/goal/models.ts
+++ b/ui/src/features/goal/models.ts
@@ -80,6 +80,14 @@ export type PomodoroStatus =
   | 'break_pause'
   | 'done';
 
+export type UpdateStudySessionData = {
+  sessionId: string;
+  title?: string;
+  description?: string;
+  planned_to_start_at?: Date | null;
+  duration?: string;
+};
+
 export type EvaluateSessionData = {
   sessionId: string;
   rating: number;


### PR DESCRIPTION
O que foi implementado
Adiciona a funcionalidade de editar uma sessão de estudo existente a partir do kanban do plano.

Mudanças:
- Novo modal de edição (edit-session-modal.tsx) pré-preenchido com os dados atuais da sessão (título, descrição, data planejada e duração), seguindo o mesmo padrão visual do modal de criação
- Menu de contexto (ícone de 3 pontos) adicionado a cada card de sessão, com a opção "Editar"
- Sessões concluídas têm a opção "Editar" desabilitada, com tooltip explicativo ao passar o mouse
- Ao salvar, as queries do goal e das métricas são invalidadas automaticamente para refletir as alterações nos gráficos
- Novo hook useUpdateStudySession e função updateStudySession que consomem o endpoint PUT /sessions/{id} já existente no backend
- 
Correção
Corrigido o valueFormat do DateTimePicker nos modais de criação e edição de sessão: o formato hh:mm (12 horas) foi substituído por HH:mm (24 horas), que fazia com que horários acima de 12h fossem salvos incorretamente (ex: 14h era interpretado como 2h).